### PR TITLE
Add support for aws subnetId

### DIFF
--- a/lib/pkgcloud/amazon/compute/client/servers.js
+++ b/lib/pkgcloud/amazon/compute/client/servers.js
@@ -168,6 +168,10 @@ exports.createServer = function createServer(options, callback) {
       || options['Placement.AvailabilityZone'];
   }
 
+  if (options.SubnetId) {
+    createOptions.SubnetId = options.subnetId;
+  }
+
   self.ec2.runInstances(createOptions, function(err, data) {
     if (err) {
       return callback(err);


### PR DESCRIPTION
subnetId is a non required attribute provided to runInstances. It allows to set the subnet of machines.
